### PR TITLE
Refactor "updated" field extraction logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ async function getModelDetails(modelName) {
 
   // Extract additional details
   details.pullCount = $("span[x-test-pull-count]").text().trim();
-  details.updated = $("span[x-test-updated]").text().trim();
+  details.updated = $('span').filter(function() { return $(this).html() === 'Updated&nbsp;'; }).parent().attr('title');
   details.size = $("span[x-test-size]")
     .text()
     .trim()


### PR DESCRIPTION
Named tag no longer exists, so we have to pull it from the title of the parent tag of the span containing the exact text "Updated&nbsp;"... Not elegant but no other choice as far as I can tell...